### PR TITLE
Add utils#isWebhookAuthentic

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,34 @@ client.accounts.transactions('acc-1', {
 });
 ```
 
+## Utils
+
+Utils houses generic helpers useful in a Button Integration.
+
+### #isWebhookAuthentic
+
+Used to verify that requests sent to a webhook endpoint are from Button and that their payload can be trusted. Returns `true` if a webhook request body matches the sent signature and `false` otherwise. See [Webhook Security](https://www.usebutton.com/developers/webhooks/#security) for more details.
+
+#### Example usage with [body-parser](https://www.npmjs.com/package/body-parser)
+
+```javascript
+var express = require('express');
+var bodyParser = require('body-parser');
+var utils = require('@button/button-client-node').utils
+
+var app = express();
+
+function verify(req, res, buf, encording) {
+  return utils.isWebhookAuthentic(
+    process.env['WEBHOOK_SECRET'],
+    buf,
+    req.headers['X-Button-Signature']
+  );
+}
+
+app.use(bodyParser.json({ verify: verify, type: 'application/json' }));
+```
+
 ## Contributing
 
 * Installing development dependencies: `npm install`

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ var utils = require('@button/button-client-node').utils
 
 var app = express();
 
-function verify(req, res, buf, encording) {
+function verify(req, res, buf, encoding) {
   return utils.isWebhookAuthentic(
     process.env['WEBHOOK_SECRET'],
     buf,

--- a/index.js
+++ b/index.js
@@ -3,14 +3,17 @@ var maybePromise = require('./lib').maybePromise;
 var request = require('./lib').request;
 var merge = require('./lib').merge;
 var compact = require('./lib').compact;
+var utils = require('./lib').utils;
 var version = require('./package.json').version;
+
+module.exports = client;
 
 var configDefaults = {
   secure: true,
   timeout: false
 };
 
-module.exports = function client(apiKey, config) {
+function client(apiKey, config) {
   //
   // #client provides the top-level interface to making API requests to Button.
   // It requires a Button API key, which can be found at
@@ -57,3 +60,5 @@ module.exports = function client(apiKey, config) {
     accounts: resources.accounts(requestOptions, maybePromiseRequest)
   };
 }
+
+client.utils = utils;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,5 +6,6 @@ module.exports = {
   maybePromise: require('./maybePromise'),
   merge: require('./merge'),
   once: require('./once'),
-  request: require('./request')
+  request: require('./request'),
+  utils: require('./utils')
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,34 @@
+var crypto = require('crypto');
+
+module.exports = {
+  isWebhookAuthentic: isWebhookAuthentic
+};
+
+function isWebhookAuthentic(webhookSecret, requestBody, sentSignature) {
+  //
+  // Used to verify that requests sent to a webhook endpoint are from Button
+  // and that their payload can be trusted. Returns true if a webhook request
+  // body matches the sent signature and false otherwise.
+  //
+  // ## Usage
+  //
+  // isWebhookAuthentic(
+  //   process.env['WEBHOOK_SECRET'],
+  //   buf,
+  //   req.headers['X-Button-Signature']
+  // );
+  //
+  // @param {String} webhookSecret your webhooks's secret key.  Find yours at
+  //   https://app.usebutton.com/webhooks.
+  // @param {String|Buffer} requestBody UTF8 encoded byte-string of the request
+  //   body
+  // @param {String} sentSignature "X-Button-Siganture" HTTP Header sent with
+  //   the request.
+  // @returns {bool} whether or not the webhook request is authentic
+  //
+  var computed_signature = crypto.createHmac('sha256', webhookSecret)
+    .update(requestBody)
+    .digest('hex');
+
+  return computed_signature === sentSignature;
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,10 +22,14 @@ function isWebhookAuthentic(webhookSecret, requestBody, sentSignature) {
   //   https://app.usebutton.com/webhooks.
   // @param {String|Buffer} requestBody UTF8 encoded byte-string of the request
   //   body
-  // @param {String} sentSignature "X-Button-Siganture" HTTP Header sent with
+  // @param {String} sentSignature "X-Button-Signature" HTTP Header sent with
   //   the request.
   // @returns {bool} whether or not the webhook request is authentic
   //
+  if (arguments.length !== 3) {
+    throw new Error('#isWebhookAuthentic must be invoked with (webhookSecret, requestBody, sentSignature)');
+  }
+
   var computed_signature = crypto.createHmac('sha256', webhookSecret)
     .update(requestBody)
     .digest('hex');

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -21,6 +21,10 @@ describe('client', function() {
     expect(typeof client('sk-XXX', {}).orders).to.eql('object');
   });
 
+  it('exposes the utils module', function() {
+    expect(typeof client.utils).to.eql('object');
+  });
+
   describe('config', function() {
     before(function() {
       nock.disableNetConnect();

--- a/test/lib/utils-test.js
+++ b/test/lib/utils-test.js
@@ -38,6 +38,10 @@ describe('lib/utils', function() {
       expect(utils.isWebhookAuthentic('secret', payload, signature)).to.be(true);
     });
 
+    it('throws a helpful message when called with wrong arity', function() {
+      expect(utils.isWebhookAuthentic).withArgs('').to.throwException(/must be invoked with/);
+    });
+
   });
 
 });

--- a/test/lib/utils-test.js
+++ b/test/lib/utils-test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var expect = require('expect.js');
+
+var utils = require('lib').utils;
+
+describe('lib/utils', function() {
+
+  describe('#isWebhookAuthentic', function() {
+
+    it('verifies authentic requests', function() {
+      var signature = '79a3a5291c94340ff0058a6319063757' +
+                      '68d706357ee86826c3c692e6b9aa6817';
+      var payload = '{ "a": 1 }';
+
+      expect(utils.isWebhookAuthentic('secret', payload, 'XXX')).to.be(false);
+      expect(utils.isWebhookAuthentic('secret', payload, signature)).to.be(true);
+      expect(utils.isWebhookAuthentic('secret?', payload, signature)).to.be(false);
+      expect(utils.isWebhookAuthentic('secret', '{ "a": 2 }', signature)).to.be(false);
+    });
+
+    it('verifies authentic requests with a buffer requestBody', function() {
+      var signature = '79a3a5291c94340ff0058a6319063757' +
+                      '68d706357ee86826c3c692e6b9aa6817';
+      var payload = new Buffer('{ "a": 1 }');
+
+      expect(utils.isWebhookAuthentic('secret', payload, 'XXX')).to.be(false);
+      expect(utils.isWebhookAuthentic('secret', payload, signature)).to.be(true);
+      expect(utils.isWebhookAuthentic('secret?', payload, signature)).to.be(false);
+      expect(utils.isWebhookAuthentic('secret', new Buffer('{ "a": 2 }'), signature)).to.be(false);
+    });
+
+    it('verifies authentic requests with a unicode requestBody', function() {
+      var signature = '3040cf48ab225ca539c1d23841175bc2' +
+                      '2e565cdb0975bd690ecaeca2c39dfcf7';
+      var payload = new Buffer('{ "a": \u1f60e }');
+
+      expect(utils.isWebhookAuthentic('secret', payload, signature)).to.be(true);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This PR introduces a generic `utils` module and an `#isWebhookAuthentic` function intended for use on a partner's servers to verify incoming webhook requests. 

Followup PR: 

1. Bump version
2. Update CHANGELOG
3. Cut `2.2.0` release + publish